### PR TITLE
Add fixed iteration count mode

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -115,3 +115,14 @@ perf_measure_cpu_rate(perf_rate_func f, double duration)
 {
 	return measure_rate(f, duration, 1, measure_cpu_time);
 }
+
+
+/**
+ * Return iterations/second for a fixed number of iterations
+ * Use a larger iteration count if you want more precision.
+ */
+double
+perf_measure_cpu_fixed(perf_rate_func f, int iterations)
+{
+    return iterations / measure_cpu_time(f, iterations);
+}

--- a/src/common.h
+++ b/src/common.h
@@ -28,6 +28,9 @@ double
 perf_measure_cpu_rate(perf_rate_func f, double minDuration);
 
 double
+perf_measure_cpu_fixed(perf_rate_func f, int iterations);
+
+double
 perf_measure_gpu_rate(perf_rate_func f, double minDuration);
 
 #endif /* COMMON_H */

--- a/src/vkoverhead.c
+++ b/src/vkoverhead.c
@@ -2813,7 +2813,7 @@ parse_args(int argc, const char **argv)
             printf(" %3u, %s\n", i + (unsigned)(ARRAY_SIZE(cases_draw) + ARRAY_SIZE(cases_submit) + ARRAY_SIZE(cases_descriptor)), cases_misc[i].name);
          exit(0);
       } else if (!strcmp(arg, "help") || !strcmp(arg, "h")) {
-         fprintf(stderr, "vkoverhead [-list] [-test/start TESTNUM] [-nocolor] [-output-only] [-draw-only] [-submit-only] [-descriptor-only] [-misc-only]\n");
+         fprintf(stderr, "vkoverhead [-list] [-test/start TESTNUM] [-nocolor] [-output-only] [-draw-only] [-submit-only] [-descriptor-only] [-misc-only] [-fixed ITERATIONS]\n");
          exit(0);
       }
    }


### PR DESCRIPTION
Add a fixed iteration count mode which does exactly what it says on the tin.

This allows moving the statistical checks to an external tool like ministat. This might or might not help getting more  consistent and statistically valid numbers.

Also helps profilers like toplev which can run the same workload multiple times while measuring different performance counters but require the workload to be deterministic.

Since different tests require vastly different iteration counts it only works when a single test is specified. Picking a good count is up to the user.

