### PR TITLE
cjson.h: include stdint.h

### DIFF
--- a/tools/cJSON.h
+++ b/tools/cJSON.h
@@ -32,6 +32,8 @@ extern "C"
 #define __WINDOWS__
 #endif
 
+#include <stdint.h>
+
 #ifdef __WINDOWS__
 
 /* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:


### PR DESCRIPTION
required for using int64_t below

(i'm not sure where this int64_t came from actually, the upstream cjson just has `int` there)

fixes the build against musl libc which is more strict with namespaces:
```
In file included from ../tools/foz_parse.c:26:
../tools/cJSON.h:117:5: error: unknown type name 'int64_t'
  117 |     int64_t valueint;
      |     ^~~~~~~
```