### PR TITLE
Prevent AMD gpus from running out of memory.

### DIFF
--- a/src/vkoverhead.c
+++ b/src/vkoverhead.c
@@ -332,6 +332,7 @@ reset_cmdbuf(void *data, void *gdata, int thread_idx)
    struct pool *p = data;
    VkResult result = VK(ResetCommandPool)(dev->dev, p->cmdpool, 0);
    VK_CHECK("ResetCommandPool", result);
+   VK(TrimCommandPool)(dev->dev, p->cmdpool, 0);
 }
 
 static void


### PR DESCRIPTION
AMD vulkan driver will not actually release memory by calling vkResetCommandPool.I think the strategy was chosen for better memory reuse. Calling vkTrimCommandPool will do the trick.