### PR TITLE
Added driver info to the initial CLI output

### DIFF
--- a/src/vkoverhead.c
+++ b/src/vkoverhead.c
@@ -3166,8 +3166,12 @@ main(int argc, char *argv[])
       VK_CHECK("QueueWaitIdle", result);
    }
    next_cmdbuf();
-   if (!output_only)
-      printf("vkoverhead running on %s:\n", dev->info.props.deviceName);
+   if (!output_only) {
+      printf("vkoverhead running on:\n");
+      printf("- device: \t%s\n", dev->info.props.deviceName);
+      printf("- driver name: \t%s\n", dev->info.driver_props.driverName);
+      printf("- driver info: \t%s\n", dev->info.driver_props.driverInfo);
+   }
    if (!submit_only && !descriptor_only && !misc_only && !output_only && start_no < (int)ARRAY_SIZE(cases_draw))
       printf("\t* draw numbers are reported as thousands of operations per second\n"
              "\t* percentages for draw cases are relative to 'draw'\n");


### PR DESCRIPTION
Hi! I added the driver's info fields to the initial output since it's quite handy if you're testing between different driver versions (or commits) back and forth.

![driver-info_vkoverhead](https://github.com/zmike/vkoverhead/assets/8086687/30a55ab5-699c-4114-a380-4ecc658216e8)