### PR TITLE
Add option platform-sdk-version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ endif
 if with_platform_android
   c_args += '-DVK_USE_PLATFORM_ANDROID_KHR'
   cpp_args += '-DVK_USE_PLATFORM_ANDROID_KHR'
+  pre_args += '-DANDROID_API_LEVEL=' + get_option('platform-sdk-version').to_string()
 endif
 
 # Check for GCC style builtins

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -29,6 +29,15 @@ option(
 )
 
 option(
+  'platform-sdk-version',
+  type : 'integer',
+  min : 25,
+  max : 10000,
+  value : 34,
+  description : 'Android Platform SDK version. Default: Android14 version.'
+)
+
+option(
   'moltenvk-dir',
   type : 'string',
   value : '',


### PR DESCRIPTION
platform-sdk-version is referenced in the build but not defined.

Also defined ANDROID_API_LEVEL which is also needed in the source.

Ref #35